### PR TITLE
CompatHelper: add new compat entry for ITensors at version 0.9, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,8 @@
 name = "QILaplace"
 uuid = "62ad503f-14a8-4749-be6f-41098d8db53a"
 license = "MIT"
-authors = ["Gauthameshwar S.", "Noufal Jaseem"]
 version = "0.1.0"
+authors = ["Gauthameshwar S.", "Noufal Jaseem"]
 
 [deps]
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
@@ -11,6 +11,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
+ITensors = "0.9"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
This pull request sets the compat entry for the `ITensors` package to `0.9`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.
Note: Consider registering a new release of your package immediately after merging this PR, as downstream packages may depend on this for tests to pass.